### PR TITLE
Add minimal FastAPI hedging UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# greeks-risk-engine
+# Greeks Risk-Engine UI
+
+Clone → install → run:
+```bash
+git clone <repo> && cd greeks-risk-engine-ui
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn greeks_ui.main:app --reload
+# browse to http://localhost:8000
+```
+Upload a .csv like:
+```
+symbol,type,cp,strike,expiry,qty,multiplier,mark_price
+AAPL,option,C,200,2025-09-19,-75,100,12.35
+AAPL,stock,,,
+,250,1,194.55
+```
+or a JSON matching HedgeRequest.positions.

--- a/greeks_risk_engine/__init__.py
+++ b/greeks_risk_engine/__init__.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from greeks_ui.hedge_io import HedgeRequest, HedgeResponse, Position, Contract
+
+
+def solve_hedge(req: HedgeRequest) -> HedgeResponse:
+    """Very small stub solver returning dummy trades and greek values."""
+    # compute simple aggregate greek exposures
+    pre = {g: 0.0 for g in ["delta", "gamma", "vega"]}
+    for p in req.positions:
+        # Use qty for delta; qty/100 for gamma; qty*0.1 for vega as dummy
+        pre["delta"] += p.qty
+        pre["gamma"] += p.qty / 100
+        pre["vega"] += p.qty * 0.1
+    # naive hedge: zero out using an opposite stock trade
+    hedge = Position(
+        symbol="HEDGE",
+        contract=Contract(type="stock"),
+        qty=-int(pre["delta"]),
+    )
+    post = {
+        "delta": pre["delta"] + hedge.qty,
+        "gamma": pre["gamma"],
+        "vega": pre["vega"],
+    }
+    return HedgeResponse(
+        status="ok",
+        objective_value=0.0,
+        pre_risk=pre,
+        post_risk=post,
+        trades=[hedge],
+        residual_exposure_ok=True,
+        violations=[],
+    )

--- a/greeks_ui/hedge_engine.py
+++ b/greeks_ui/hedge_engine.py
@@ -1,0 +1,9 @@
+from greeks_ui.hedge_io import HedgeRequest, HedgeResponse
+
+# 👉  assumes user already pip-installed or symlinked their engine package.
+from greeks_risk_engine import solve_hedge as _core_solver   # noqa: E402
+
+
+def solve(req: HedgeRequest) -> HedgeResponse:
+    """Delegate to core engine; re-cast result into our HedgeResponse."""
+    return HedgeResponse.model_validate(_core_solver(req))

--- a/greeks_ui/hedge_io.py
+++ b/greeks_ui/hedge_io.py
@@ -1,0 +1,49 @@
+from typing import List, Optional, Literal, Dict
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+
+class Contract(BaseModel):
+    type: Literal["stock", "option", "etf"]
+    cp: Optional[Literal["C", "P"]] = None
+    strike: Optional[float] = None
+    expiry: Optional[datetime] = None
+
+
+class Position(BaseModel):
+    id: Optional[str] = None
+    symbol: str
+    contract: Contract = Field(default_factory=lambda: Contract(type="option"))
+    qty: int
+    multiplier: int = 1
+    mark_price: Optional[float] = None
+
+
+class TargetLimit(BaseModel):
+    max_abs: Optional[float] = None
+    min: Optional[float] = None
+    max: Optional[float] = None
+
+
+class HedgeRequest(BaseModel):
+    timestamp_utc: datetime
+    positions: List[Position]
+    greeks_to_neutralize: List[str]
+    target_limits: Dict[str, TargetLimit]
+    objective: str
+    cost_per_contract: float
+    allowed_hedges: List[Position]
+    solver: str = "osqp"
+    max_iters: int = 10_000
+    tolerance: float = 1e-6
+    dry_run: bool = False
+
+
+class HedgeResponse(BaseModel):
+    status: str
+    objective_value: float
+    pre_risk: Dict[str, float]
+    post_risk: Dict[str, float]
+    trades: List[Position]
+    residual_exposure_ok: bool
+    violations: List[Dict[str, object]]

--- a/greeks_ui/main.py
+++ b/greeks_ui/main.py
@@ -1,0 +1,90 @@
+from fastapi import FastAPI, Request, UploadFile, Form
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+import csv
+import io
+import json
+import datetime as dt
+from greeks_ui.hedge_io import HedgeRequest, Position, Contract, TargetLimit
+from greeks_ui.hedge_engine import solve
+from typing import Optional, Literal, cast
+
+app = FastAPI(title="Greeks Hedger UI")
+templates = Jinja2Templates(directory="greeks_ui/templates")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def landing(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+def csv_to_positions(raw: str) -> list[Position]:
+    rdr = csv.DictReader(io.StringIO(raw))
+    out = []
+    for row in rdr:
+        out.append(
+            Position(
+                symbol=row["symbol"],
+                contract=Contract(
+                    type=cast(
+                        Literal["stock", "option", "etf"],
+                        row.get("type", "option"),
+                    ),
+                    cp=cast(
+                        Optional[Literal["C", "P"]],
+                        row.get("cp") or None,
+                    ),
+                    strike=float(row["strike"]) if row.get("strike") else None,
+                    expiry=(
+                        dt.datetime.fromisoformat(row["expiry"])
+                        if row.get("expiry")
+                        else None
+                    ),
+                ),
+                qty=int(row["qty"]),
+                multiplier=int(row.get("multiplier", 1)),
+                mark_price=(
+                    float(row["mark_price"]) if row.get("mark_price") else None
+                ),
+            )
+        )
+    return out
+
+
+@app.post("/solve", response_class=HTMLResponse)
+async def solve_ui(
+    request: Request,
+    file: UploadFile,
+    delta_limit: float = Form(...),
+    gamma_limit: float = Form(...),
+    vega_limit: float = Form(...),
+) -> HTMLResponse:
+    raw = (await file.read()).decode()
+    positions = (
+        csv_to_positions(raw)
+        if file.filename and file.filename.endswith(".csv")
+        else [Position.model_validate(p) for p in json.loads(raw)]
+    )
+
+    req = HedgeRequest(
+        timestamp_utc=dt.datetime.utcnow(),
+        positions=positions,
+        greeks_to_neutralize=["delta", "gamma", "vega"],
+        target_limits={
+            "delta": TargetLimit(max_abs=delta_limit),
+            "gamma": TargetLimit(max_abs=gamma_limit),
+            "vega":  TargetLimit(max_abs=vega_limit),
+        },
+        objective="min_variance",
+        cost_per_contract=1.0,
+        allowed_hedges=[],  # let engine pick full chain
+    )
+    res = solve(req)
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "response": res.model_dump(mode="json"),
+            "json": json.dumps(res.model_dump(mode="json")),
+        },
+    )

--- a/greeks_ui/templates/index.html
+++ b/greeks_ui/templates/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Greeks Hedger</title>
+  <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+  <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
+  <style>
+    body{font-family:system-ui;margin:2rem}
+    table,th,td{border:1px solid #999;border-collapse:collapse;padding:0.3rem}
+    th{background:#f2f2f2}
+  </style>
+</head>
+<body>
+<h2>Upload Portfolio → Solve Hedge</h2>
+<form hx-post="/solve" hx-target="#results" hx-encoding="multipart/form-data">
+  <input type="file" name="file" accept=".json,.csv" required>
+  ∣ Δ limit <input type="number" step="any" name="delta_limit" value="5000">
+  ∣ Γ limit <input type="number" step="any" name="gamma_limit" value="100">
+  ∣ ν limit <input type="number" step="any" name="vega_limit"  value="2000">
+  <button type="submit">Solve</button>
+</form>
+
+<div id="results" hx-swap="outerHTML">
+  {% if response %}
+    <h3>Trades</h3>
+    <table>
+      <tr><th>Symbol</th><th>Contract</th><th>Qty</th></tr>
+      {% for t in response['trades'] %}
+        {% set c=t['contract'] %}
+        <tr>
+          <td>{{t['symbol']}}</td>
+          <td>{{ c['type']=='option'
+                and (c['cp'] ~ c['strike'] ~ '@' ~ c['expiry'][:10])
+                or  c['type'] }}</td>
+          <td>{{t['qty']}}</td>
+        </tr>
+      {% endfor %}
+    </table>
+
+    <h3>Greeks</h3>
+    <div id="greeks"></div>
+    <script>
+      const data={{json|safe}};
+      const keys=Object.keys(data.pre_risk);
+      Plotly.newPlot("greeks",[
+        {x:keys,y:keys.map(k=>data.pre_risk[k]),name:"Pre",type:"bar"},
+        {x:keys,y:keys.map(k=>data.post_risk[k]),name:"Post",type:"bar"}
+      ],{barmode:"group"});
+    </script>
+
+    {% if not response['residual_exposure_ok'] %}
+      <h3 style="color:red">Violations</h3>
+      <pre>{{response['violations']}}</pre>
+    {% endif %}
+  {% endif %}
+</div>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.111
+uvicorn[standard]>=0.29
+pydantic>=2.7
+jinja2>=3.1
+osqp>=0.6
+plotly>=5.22
+python-multipart>=0.0.9
+httptools>=0.6


### PR DESCRIPTION
## Summary
- add FastAPI-based hedging UI
- provide pydantic models for hedge engine
- wrap external solver
- create example HTML template for HTMX/Plotly interface
- include stub `greeks_risk_engine` for local runs
- document installation and usage instructions

## Testing
- `flake8 .`
- `mypy --strict greeks_ui greeks_risk_engine`
- `uvicorn greeks_ui.main:app --reload --port 8000` *(manual check)*

------
https://chatgpt.com/codex/tasks/task_e_686c5433e378832b904484455633e071